### PR TITLE
don't send requests to autologin through proxy

### DIFF
--- a/autologin_middleware/middleware.py
+++ b/autologin_middleware/middleware.py
@@ -148,7 +148,7 @@ class AutologinMiddleware:
             body=json.dumps(params).encode(),
             headers={'content-type': 'application/json'},
             dont_filter=True,
-            meta={'skip_autologin': True},
+            meta={'skip_autologin': True, 'proxy': None},
             priority=1000)
 
     @inlineCallbacks


### PR DESCRIPTION
When `HTTP(S)_PROXY` option is enabled then Scrapy spider is likely to send all requests through this proxy (given that an appropriate middleware is enabled). AutologinMiddleware passes this option to Autologin, so that Autologin uses the same proxy. But the request to Autologin itself is still proxied. This cause problems e.g. when Autologin is only available at localhost.

After this change no proxy will be used for connecting to Autologin API.

We can add another option, to set a proxy for connecting to Autologin API, but I think this use case shouldn't be common, we can do it later if needed.