### PR TITLE
Do not erase callbacks

### DIFF
--- a/autologin_middleware/middleware.py
+++ b/autologin_middleware/middleware.py
@@ -77,7 +77,6 @@ class AutologinMiddleware:
                 raise IgnoreRequest
             # Save original request to be able to retry it in case of logout
             req_copy = request.replace(meta=deepcopy(request.meta))
-            req_copy.callback = req_copy.errback = None
             request.meta['_autologin'] = autologin_meta = {'request': req_copy}
             # TODO - it should be possible to put auth cookies into the
             # cookiejar in process_response (but also check non-splash)

--- a/autologin_middleware/middleware.py
+++ b/autologin_middleware/middleware.py
@@ -78,8 +78,14 @@ class AutologinMiddleware:
                 raise IgnoreRequest
             # Save original request to be able to retry it in case of logout
             req_copy = request.replace(meta=deepcopy(request.meta))
-            request.meta['_autologin'] = autologin_meta = {
-                'request': request_to_dict(req_copy, spider=spider)}
+            request.meta['_autologin'] = autologin_meta = {}
+            try:
+                autologin_meta['request'] = request_to_dict(
+                    req_copy, spider=spider)
+            except ValueError:
+                # Serialization failed, but it might be ok if we do not persist
+                # requests, so store the request itself here.
+                autologin_meta['request'] = req_copy
             # TODO - it should be possible to put auth cookies into the
             # cookiejar in process_response (but also check non-splash)
             if self.auth_cookies:
@@ -161,7 +167,10 @@ class AutologinMiddleware:
         """
         if request.meta.get('_autologin') and self.is_logout(response):
             autologin_meta = request.meta['_autologin']
-            retryreq = request_from_dict(autologin_meta['request'], spider)
+            if isinstance(autologin_meta['request'], dict):
+                retryreq = request_from_dict(autologin_meta['request'], spider)
+            else:
+                retryreq = autologin_meta['request'].copy()
             retryreq.dont_filter = True
             logger.debug(
                 'Logout at %s: %s', retryreq.url, _response_cookies(response))

--- a/autologin_middleware/middleware.py
+++ b/autologin_middleware/middleware.py
@@ -8,6 +8,7 @@ import scrapy
 from scrapy.downloadermiddlewares.cookies import CookiesMiddleware
 from scrapy.exceptions import IgnoreRequest, NotConfigured
 from scrapy.http.cookies import CookieJar
+from scrapy.utils.reqser import request_to_dict, request_from_dict
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 
@@ -77,7 +78,8 @@ class AutologinMiddleware:
                 raise IgnoreRequest
             # Save original request to be able to retry it in case of logout
             req_copy = request.replace(meta=deepcopy(request.meta))
-            request.meta['_autologin'] = autologin_meta = {'request': req_copy}
+            request.meta['_autologin'] = autologin_meta = {
+                'request': request_to_dict(req_copy, spider=spider)}
             # TODO - it should be possible to put auth cookies into the
             # cookiejar in process_response (but also check non-splash)
             if self.auth_cookies:
@@ -159,7 +161,7 @@ class AutologinMiddleware:
         """
         if request.meta.get('_autologin') and self.is_logout(response):
             autologin_meta = request.meta['_autologin']
-            retryreq = autologin_meta['request'].copy()
+            retryreq = request_from_dict(autologin_meta['request'], spider)
             retryreq.dont_filter = True
             logger.debug(
                 'Logout at %s: %s', retryreq.url, _response_cookies(response))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -353,8 +353,8 @@ class StoppingSpider(TestSpider):
         for item in super(StoppingSpider, self).parse(response):
             yield item
         if not self.state['was_stopped']:
-            self.crawler.engine.close()
             self.state['was_stopped'] = True
+            self.crawler.stop()
 
 
 class TestAutoLoginResume(SpiderTestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import json
 import uuid
 from six.moves.urllib.parse import urlsplit, urlunsplit
+import tempfile
 
 from flaky import flaky
 import scrapy
@@ -42,7 +43,10 @@ class TestSpider(scrapy.Spider):
                 self.link_extractor.extract_links(response)
                 if not self._looks_like_logout(link, response)}
         for url in urls:
-            yield scrapy.Request(url, callback=self.parse)
+            yield self.make_request(url)
+
+    def make_request(self, url):
+        return scrapy.Request(url, callback=self.parse)
 
     def _looks_like_logout(self, link, response):
         if not self.settings.getbool('AUTOLOGIN_ENABLED') or not \
@@ -53,6 +57,7 @@ class TestSpider(scrapy.Spider):
 
 class SpiderTestCase(TestCase):
     settings = {}
+    SpiderCls = TestSpider
 
     def setUp(self):
         settings = {
@@ -70,7 +75,7 @@ class SpiderTestCase(TestCase):
         }
         settings.update(self.settings)
         runner = CrawlerRunner(settings)
-        self.crawler = runner.create_crawler(TestSpider)
+        self.crawler = runner.create_crawler(self.SpiderCls)
 
 
 def html(content):
@@ -314,3 +319,34 @@ class TestAutologinRequest(SpiderTestCase):
         assert data['settings']['SPLASH_URL'] == \
                self.crawler.settings.get('SPLASH_URL')
 
+
+class CustomParseSpider(TestSpider):
+    def start_requests(self):
+        for url in self.start_urls:
+            yield self.make_request(url)
+
+    def make_request(self, url):
+        return scrapy.Request(url, callback=self.custom_parse)
+
+    def parse(self, response):
+        assert False
+
+    def custom_parse(self, response):
+        return super(CustomParseSpider, self).parse(response)
+
+
+class TestAutoLoginCustomParseSpider(TestAutologin):
+    SpiderCls = CustomParseSpider
+
+
+class TestAutoLoginDiskQueue(TestAutologin):
+    @property
+    def settings(self):
+        self.tempdir = tempfile.mkdtemp()
+        settings = {
+            'JOBDIR': self.tempdir,
+            'SCHEDULER_DISK_QUEUE': 'scrapy.squeues.PickleFifoDiskQueue',
+            'SCHEDULER_MEMORY_QUEUE': 'scrapy.squeues.FifoMemoryQueue',
+        }
+        settings.update(TestAutologin.settings)
+        return settings


### PR DESCRIPTION
Fixes #6: instead of erasing callbacks, use ``request_to_dict``/``request_from_dict``, as during request serialization. If they fail, just store original request (maybe we do not need serialization at all).

I'd like to check if it is possible to remove this request serialization altogether in #10.